### PR TITLE
updated pty.cpp to the new Nan 2.0.0 signatures

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "extend": "^2.0.0",
-    "nan": "^1.4.1"
+    "nan": "^2.0.9"
   },
   "gypfile": true,
   "devDependencies": {


### PR DESCRIPTION
Hi Gottox,
I ran a script that updates the signatures inside pty.cpp to work with nan 2.0.9;
Let me just make clear that the last time i typed any cpp was 15 years ago and im not sure in the quality of my conversion. 
either way the tests pass and i hope you will find this contribution useful. 

a warning; there are 3 symbols that the compiler couldn't find so i commented them out: IUCLC, OLCLC and XCASE 

Also i switched the signature of the o->Set method to use <v8::Number> instead of Integer as integer couldn't be resolved to the correct header method (maybe this opens a buffer overflow vulnerability)

Thanks,
Petar