### PR TITLE
Preventing process leaks when the controlling shell program dies.

### DIFF
--- a/lib/child_pty.js
+++ b/lib/child_pty.js
@@ -45,8 +45,6 @@ module.exports.PtyRwStream = PtyRwStream;
 PtyRwStream.prototype._destroy = function(ex, cb) {
 	if(ex && ex.code === 'EIO')
 		ex = null;
-	
-	// Calls destructor of net.Socket
 	PtyRwStream.super_.prototype._destroy.call(this, ex, cb);
 };
 
@@ -74,17 +72,16 @@ PtyRwStream.prototype.resize = function(size) {
 
 module.exports.spawn = function(command, args, options) {
 	var i, ptyStream, ptyFds = [];
-	
 	// Argument Parsing
 	if(!util.isArray(args)) {
 		options = args;
 		args = [];
 	}
-	
+
 	options = extend(true, { stdio: [] }, options, {
 		detached: true
 	});
-	
+
 	// Opening and configuring the PTY.
 	term = pty.open(options);
 	termios.setattr(term.master_fd, options);

--- a/lib/child_pty.js
+++ b/lib/child_pty.js
@@ -45,6 +45,8 @@ module.exports.PtyRwStream = PtyRwStream;
 PtyRwStream.prototype._destroy = function(ex, cb) {
 	if(ex && ex.code === 'EIO')
 		ex = null;
+	
+	// Calls destructor of net.Socket
 	PtyRwStream.super_.prototype._destroy.call(this, ex, cb);
 };
 
@@ -72,16 +74,17 @@ PtyRwStream.prototype.resize = function(size) {
 
 module.exports.spawn = function(command, args, options) {
 	var i, ptyStream, ptyFds = [];
+	
 	// Argument Parsing
 	if(!util.isArray(args)) {
 		options = args;
 		args = [];
 	}
-
+	
 	options = extend(true, { stdio: [] }, options, {
 		detached: true
 	});
-
+	
 	// Opening and configuring the PTY.
 	term = pty.open(options);
 	termios.setattr(term.master_fd, options);
@@ -96,8 +99,9 @@ module.exports.spawn = function(command, args, options) {
 	}
 
 	// add a message channel to retrieve error codes from EXEC_HELPER
-	args.unshift(options.stdio.push('pipe') - 1, command);
-
+	// also add file descriptor of the master pty, so the child can close it
+	args.unshift(options.stdio.push('pipe') - 1, term.master_fd, command);
+	
 	child = child_process.spawn(EXEC_HELPER, args, options);
 	child.pty = ptyStream;
 	fs.close(term.slave_fd);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "child_pty",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "provides a child_process.spawn()-like interface with pty support.",
   "main": "index.js",
   "scripts": {

--- a/src/exechelper.cpp
+++ b/src/exechelper.cpp
@@ -10,14 +10,16 @@
 int main(int argc, char *argv[]) {
 	int state_fd;
 	uint32_t rv;
-
-	if(argc < 3)
+	
+	if(argc < 4)
 		return EXIT_FAILURE;
+	int master_fd = atoi(argv[2]);
 	state_fd = atoi(argv[1]);
-	if (fcntl(state_fd, F_SETFD, fcntl(state_fd, F_GETFD) | FD_CLOEXEC) >= 0 &&
+	if (fcntl(master_fd, F_SETFD, fcntl(master_fd, F_GETFD) | FD_CLOEXEC) >= 0 &&
+			fcntl(state_fd, F_SETFD, fcntl(state_fd, F_GETFD) | FD_CLOEXEC) >= 0 &&
 			ioctl(STDIN_FILENO, TIOCSCTTY, NULL) >= 0) {
-		argc -= 2;
-		memmove(argv, argv + 2, argc * sizeof(char*));
+		argc -= 3;
+		memmove(argv, argv + 3, argc * sizeof(char*));
 		argv[argc] = NULL;
 		execvp(argv[0], argv);
 	}

--- a/src/exechelper.cpp
+++ b/src/exechelper.cpp
@@ -10,7 +10,7 @@
 int main(int argc, char *argv[]) {
 	int state_fd;
 	uint32_t rv;
-	
+
 	if(argc < 4)
 		return EXIT_FAILURE;
 	int master_fd = atoi(argv[2]);


### PR DESCRIPTION
This bug can be reproduced using the node-webterm demo and going through the following steps:

1. run node-webterm demo
2. open localhost:3000
3. run "top"
4. close browser tab

After step three, there will be 3 processes with the same session id: the "sh" that echoed a message, a second "sh", and "top". Where the first "sh" is the session leader. This is not supposed to happen.

After step 4, the second "sh" remains alive. It never got a SIGHUP. It is now rooted PID the init process (usually PID 1), belonging to a session id without a session leader. This process will be sleeping, waiting for a signal that will never come. It is the job of the kernel to send a SIGHUP to all processes in a session when the controlling terminal is dead. In case of a pseudo terminal , the kernel determines the terminal is dead when this the master side of pty is closed.  

These changes fixes this bug. The leak occurs because master_fd is leaked to all child processes consequently the kernel doesn’t know the controlling terminal is dead

The leak occurs because every process that is forked has access to that file descriptor for master_fd. The initial process, nodejs, has access to those file descriptors because it created them. Exechelper closes the slave side of the pty, but it has access to an open file descriptor that it isn’t aware of (master_fd) is passed along to the other program (/bin/sh). This then gets passed along to all the processes that launched. Since the code relies on the childprocess.spawn(), we felt it better to clean up inside exec helper.

User @aumathew and I have modified EXEC_HELPER to make sure it will close the master pty file descriptor when execvp() is called. This will ensure that the all processes in the session is sent a SIGHUP when the controlling terminal of that session dies.  

You can verify this by calling ptyRwStream.destroy(). One doesn’t need to explicitly send SIGHUP to the processes. 
